### PR TITLE
update to one more robust Sem_open

### DIFF
--- a/31/common_threads.h
+++ b/31/common_threads.h
@@ -6,11 +6,9 @@
 #include <pthread.h>
 #include <semaphore.h>
 #include <sys/stat.h> // For mode constants
-#include <string.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 
 #define Pthread_create(thread, attr, start_routine, arg)                       \
   assert(pthread_create(thread, attr, start_routine, arg) == 0)
@@ -42,28 +40,21 @@
 
 /*
 If some programs created sem by sem_open but not destroyed it maybe due to the deadlock and Ctrl-C or others,
-then the next time "Sem_open" will skip the create operation and not init as expected.
-Here assume that sem is accidentally stored in /dev/shm/ with format like /dev/shm/sem.foo
+then with "O_CREAT" flag, the next time "Sem_open" will skip the create operation and not init as expected.
 */
-void check_shm(char *obj_name){
-  char *shm_path = (char *)malloc(100*sizeof(char));
-  strcpy(shm_path,"/dev/shm/sem.");
-  strcat(shm_path,obj_name+1);
-  if (access(shm_path,F_OK)==0)
-    Sem_unlink(obj_name);
-  free(shm_path);
-}
-
 
 sem_t *Sem_open(char *name, int value) {
   sem_t *sem;
-  check_shm(name);
-  /*
-  "O_CREAT|O_EXCL" also fine. If "EEXIST" then we recall "Sem_open".
-  This has more overheads when failure but less overheads when success.
-  */
-  sem = sem_open(name, O_CREAT, S_IRWXU, value);
-  assert(sem != SEM_FAILED);
+  sem = sem_open(name, O_CREAT|O_EXCL, S_IRWXU, value);
+  if (sem == SEM_FAILED){
+    if (errno==EEXIST){
+      Sem_unlink(name);
+      sem = Sem_open(name, value);
+    }else{
+      fprintf(stderr,"sem_open error");
+      exit(-1);
+    }
+  }
   return sem;
 }
 


### PR DESCRIPTION
Maybe the last my pull request is too trivial. Hope this one is not.

If there is something like `/dev/shm/sem.lock` already due to some problems like the deadlock and then quit forcefully, then `sem_open` **won't create and init as expected**.

I added one check before `sem_open` to solve the problem.

Hope that the author can check my code when he is not busy.